### PR TITLE
Update dependency versions and add authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Bazaarvoice Common Data DAO
 
 This project contains general data DAO modules.
 
+## Modules
 ```
 commons-data-parent    - Parent module
 commons-data-model     - The Data Model module contains generally useful classes for building up models
@@ -11,3 +12,49 @@ commons-data-json      - Commons Data JSON contains many useful classes for work
 commons-data-mongodao  - The Mongo DAO module is an implementation of the general DAO for MongoDB
 ```
 
+## Supported Versions
+_Check [`parent/pom.xml`](parent/pom.xml) for latest version information._
+
+At date of writing (Jan 2021) the following versions are used:
+- Spring 5.3.3
+- MongoDB driver (legacy version) 4.2.0
+- Guava 30.1-jre
+- JSON 20201115
+
+## Usage
+### Spring XML-based configuration example
+- Access to Mongo server/cluster via `MongoAccessService` using username/password auth (via `MongoCredentialsFactoryBean`) and configuring `readPreference`,
+`connectionsPerHost` and `writeConcern` (via `MongoClientOptionsFactoryBean`):
+```xml
+<bean id="MongoAccessService" class="com.bazaarvoice.commons.data.dao.mongo.impl.MongoAccessServiceImpl" abstract="true">
+    <property name="serverAuthorities" value="${mongo.serverAuthorities}"/>
+    <property name="mongoClientOptions">
+        <bean class="com.bazaarvoice.commons.data.dao.mongo.MongoClientOptionsFactoryBean">
+            <property name="readPreference">
+                <bean class="com.mongodb.ReadPreference" factory-method="valueOf">
+                    <constructor-arg value=""/>
+                </bean>
+            </property>
+            <property name="connectionsPerHost" value="30"/>
+            <property name="writeConcern">
+                <bean class="com.mongodb.WriteConcern" factory-method="valueOf">
+                    <constructor-arg value="ACKNOWLEDGED"/>
+                </bean>
+            </property>
+        </bean>
+    </property>
+    <property name="mongoCredential">
+        <bean class="com.bazaarvoice.commons.data.dao.mongo.MongoCredentialsFactoryBean" >
+            <constructor-arg index="0" value="username"/>
+            <constructor-arg index="1" value="password"/>
+            <constructor-arg index="2" value="authDb"/>
+        </bean>
+    </property>
+</bean>
+```
+- Access database `databaseName` via child bean: 
+```xml
+<bean id="DbMongoAccessService" class="com.bazaarvoice.commons.data.dao.mongo.impl.MongoAccessServiceImpl" parent="MongoAccessService">
+    <property name="databaseName" value="databaseName"/>
+</bean>
+```

--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.commons.data</groupId>
         <artifactId>data-parent</artifactId>
-        <version>4.5-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.commons.data</groupId>
         <artifactId>data-parent</artifactId>
-        <version>4.5-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -80,6 +80,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/json/src/main/java/com/bazaarvoice/commons/data/dao/json/GenericDelegatingJSONMarshaller.java
+++ b/json/src/main/java/com/bazaarvoice/commons/data/dao/json/GenericDelegatingJSONMarshaller.java
@@ -1,6 +1,6 @@
 package com.bazaarvoice.commons.data.dao.json;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
 
 import java.util.Map;
@@ -77,7 +77,7 @@ public class GenericDelegatingJSONMarshaller<T> extends AbstractDelegatingJSONMa
 
         @Override
         public String toString() {
-            return Objects.toStringHelper(this).
+            return MoreObjects.toStringHelper(this).
                     add("_name", _name).
                     add("_delegateItemClass", _delegateItemClass).
                     toString();

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.commons.data</groupId>
         <artifactId>data-parent</artifactId>
-        <version>4.5-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/mongodao/pom.xml
+++ b/mongodao/pom.xml
@@ -51,7 +51,7 @@
         <!-- Data -->
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
+            <artifactId>mongodb-driver-legacy</artifactId>
         </dependency>
 
         <!-- Commons -->

--- a/mongodao/pom.xml
+++ b/mongodao/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.commons.data</groupId>
         <artifactId>data-parent</artifactId>
-        <version>4.5-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/mongodao/src/main/java/com/bazaarvoice/commons/data/dao/mongo/MongoClientOptionsFactoryBean.java
+++ b/mongodao/src/main/java/com/bazaarvoice/commons/data/dao/mongo/MongoClientOptionsFactoryBean.java
@@ -2,42 +2,40 @@ package com.bazaarvoice.commons.data.dao.mongo;
 
 import com.mongodb.DBDecoderFactory;
 import com.mongodb.DBEncoderFactory;
-import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 
-import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
  * A factory bean for construction of a {@link MongoClientOptions} instance.
  * Source: http://docs.spring.io/spring-data/data-mongodb/docs/current/api/org/springframework/data/mongodb/core/MongoClientOptionsFactoryBean.html
- * Updated with additional configurational configuratoin properties.
+ * Updated with additional configuration properties.
  */
 public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClientOptions> {
 
     private static final MongoClientOptions DEFAULT_MONGO_OPTIONS = MongoClientOptions.builder().build();
 
-    private String description = DEFAULT_MONGO_OPTIONS.getDescription();
+//    private String description = DEFAULT_MONGO_OPTIONS.getDescription();
     private int minConnectionsPerHost = DEFAULT_MONGO_OPTIONS.getMinConnectionsPerHost();
     private int connectionsPerHost = DEFAULT_MONGO_OPTIONS.getConnectionsPerHost();
-    private int threadsAllowedToBlockForConnectionMultiplier = DEFAULT_MONGO_OPTIONS
-            .getThreadsAllowedToBlockForConnectionMultiplier();
+//    private int threadsAllowedToBlockForConnectionMultiplier = DEFAULT_MONGO_OPTIONS
+//            .getThreadsAllowedToBlockForConnectionMultiplier();
     private int maxWaitTime = DEFAULT_MONGO_OPTIONS.getMaxWaitTime();
     private int maxConnectionIdleTime = DEFAULT_MONGO_OPTIONS.getMaxConnectionIdleTime();
     private int maxConnectionLifeTime = DEFAULT_MONGO_OPTIONS.getMaxConnectionLifeTime();
     private int connectTimeout = DEFAULT_MONGO_OPTIONS.getConnectTimeout();
     private int socketTimeout = DEFAULT_MONGO_OPTIONS.getSocketTimeout();
-    private boolean socketKeepAlive = DEFAULT_MONGO_OPTIONS.isSocketKeepAlive();
+//    private boolean socketKeepAlive = DEFAULT_MONGO_OPTIONS.isSocketKeepAlive();
     private ReadPreference readPreference = DEFAULT_MONGO_OPTIONS.getReadPreference();
     private DBDecoderFactory dbDecoderFactory = DEFAULT_MONGO_OPTIONS.getDbDecoderFactory();
     private DBEncoderFactory dbEncoderFactory = DEFAULT_MONGO_OPTIONS.getDbEncoderFactory();
     private WriteConcern writeConcern = DEFAULT_MONGO_OPTIONS.getWriteConcern();
-    private SocketFactory socketFactory = DEFAULT_MONGO_OPTIONS.getSocketFactory();
+//    private SocketFactory socketFactory = DEFAULT_MONGO_OPTIONS.getSocketFactory();
     private boolean cursorFinalizerEnabled = DEFAULT_MONGO_OPTIONS.isCursorFinalizerEnabled();
-    private boolean alwaysUseMBeans = DEFAULT_MONGO_OPTIONS.isAlwaysUseMBeans();
+//    private boolean alwaysUseMBeans = DEFAULT_MONGO_OPTIONS.isAlwaysUseMBeans();
     private int heartbeatFrequency = DEFAULT_MONGO_OPTIONS.getHeartbeatFrequency();
     private int minHeartbeatFrequency = DEFAULT_MONGO_OPTIONS.getMinHeartbeatFrequency();
     private int heartbeatConnectTimeout = DEFAULT_MONGO_OPTIONS.getHeartbeatConnectTimeout();
@@ -47,14 +45,6 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
     private boolean ssl;
     private SSLSocketFactory sslSocketFactory;
 
-    /**
-     * Set the {@link MongoClient} description.
-     *
-     * @param description
-     */
-    public void setDescription(String description) {
-        this.description = description;
-    }
 
     /**
      * Set the minimum number of connections per host.
@@ -75,16 +65,16 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
         this.connectionsPerHost = connectionsPerHost;
     }
 
-    /**
-     * Set the multiplier for connectionsPerHost for # of threads that can block. Default is 5. If connectionsPerHost is
-     * 10, and threadsAllowedToBlockForConnectionMultiplier is 5, then 50 threads can block more than that and an
-     * exception will be thrown.
-     *
-     * @param threadsAllowedToBlockForConnectionMultiplier
-     */
-    public void setThreadsAllowedToBlockForConnectionMultiplier(int threadsAllowedToBlockForConnectionMultiplier) {
-        this.threadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;
-    }
+//    /**
+//     * Set the multiplier for connectionsPerHost for # of threads that can block. Default is 5. If connectionsPerHost is
+//     * 10, and threadsAllowedToBlockForConnectionMultiplier is 5, then 50 threads can block more than that and an
+//     * exception will be thrown.
+//     *
+//     * @param threadsAllowedToBlockForConnectionMultiplier
+//     */
+//    public void setThreadsAllowedToBlockForConnectionMultiplier(int threadsAllowedToBlockForConnectionMultiplier) {
+//        this.threadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;
+//    }
 
     /**
      * Set the max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
@@ -131,14 +121,14 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
         this.socketTimeout = socketTimeout;
     }
 
-    /**
-     * Set the keep alive flag, controls whether or not to have socket keep alive timeout. Defaults to false.
-     *
-     * @param socketKeepAlive
-     */
-    public void setSocketKeepAlive(boolean socketKeepAlive) {
-        this.socketKeepAlive = socketKeepAlive;
-    }
+//    /**
+//     * Set the keep alive flag, controls whether or not to have socket keep alive timeout. Defaults to false.
+//     *
+//     * @param socketKeepAlive
+//     */
+//    public void setSocketKeepAlive(boolean socketKeepAlive) {
+//        this.socketKeepAlive = socketKeepAlive;
+//    }
 
     /**
      * Set the {@link ReadPreference}.
@@ -159,12 +149,12 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
         this.writeConcern = writeConcern;
     }
 
-    /**
-     * @param socketFactory
-     */
-    public void setSocketFactory(SocketFactory socketFactory) {
-        this.socketFactory = socketFactory;
-    }
+//    /**
+//     * @param socketFactory
+//     */
+//    public void setSocketFactory(SocketFactory socketFactory) {
+//        this.socketFactory = socketFactory;
+//    }
 
 
     public void setCursorFinalizerEnabled(boolean cursorFinalizerEnabled) {
@@ -243,17 +233,17 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
     @Override
     protected MongoClientOptions createInstance() throws Exception {
 
-        SocketFactory socketFactoryToUse = ssl ? (sslSocketFactory != null ? sslSocketFactory : SSLSocketFactory
-                .getDefault()) : this.socketFactory;
+    //        SocketFactory socketFactoryToUse = ssl ? (sslSocketFactory != null ? sslSocketFactory : SSLSocketFactory
+    //                .getDefault()) : this.socketFactory;
 
         return MongoClientOptions.builder() //
-                .alwaysUseMBeans(this.alwaysUseMBeans) //
+//                .alwaysUseMBeans(this.alwaysUseMBeans) //
                 .connectionsPerHost(this.connectionsPerHost) //
                 .connectTimeout(connectTimeout) //
                 .cursorFinalizerEnabled(cursorFinalizerEnabled) //
                 .dbDecoderFactory(dbDecoderFactory) //
                 .dbEncoderFactory(dbEncoderFactory) //
-                .description(description) //
+//                .description(description) //
                 .heartbeatConnectTimeout(heartbeatConnectTimeout) //
                 .heartbeatFrequency(heartbeatFrequency) //
                 .heartbeatSocketTimeout(heartbeatSocketTimeout) //
@@ -264,10 +254,10 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
                 .minHeartbeatFrequency(minHeartbeatFrequency) //
                 .readPreference(readPreference) //
                 .requiredReplicaSetName(requiredReplicaSetName) //
-                .socketFactory(socketFactoryToUse) //
-                .socketKeepAlive(socketKeepAlive) //
+//                .socketFactory(socketFactoryToUse) //
+//                .socketKeepAlive(socketKeepAlive) //
                 .socketTimeout(socketTimeout) //
-                .threadsAllowedToBlockForConnectionMultiplier(threadsAllowedToBlockForConnectionMultiplier) //
+//                .threadsAllowedToBlockForConnectionMultiplier(threadsAllowedToBlockForConnectionMultiplier) //
                 .writeConcern(writeConcern).build();
     }
 

--- a/mongodao/src/main/java/com/bazaarvoice/commons/data/dao/mongo/MongoClientOptionsFactoryBean.java
+++ b/mongodao/src/main/java/com/bazaarvoice/commons/data/dao/mongo/MongoClientOptionsFactoryBean.java
@@ -1,138 +1,112 @@
 package com.bazaarvoice.commons.data.dao.mongo;
 
+import com.mongodb.AutoEncryptionSettings;
 import com.mongodb.DBDecoderFactory;
 import com.mongodb.DBEncoderFactory;
 import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCompressor;
+import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
+import com.mongodb.event.ClusterListener;
+import com.mongodb.event.CommandListener;
+import com.mongodb.selector.ServerSelector;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.bson.UuidRepresentation;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
+import java.util.List;
 
 /**
- * A factory bean for construction of a {@link MongoClientOptions} instance.
- * Source: http://docs.spring.io/spring-data/data-mongodb/docs/current/api/org/springframework/data/mongodb/core/MongoClientOptionsFactoryBean.html
- * Updated with additional configuration properties.
+ * Spring factory bean for construction of a {@link MongoClientOptions} instance
+ * Deprecated properties are stubbed out for backward compatibility
  */
 public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClientOptions> {
 
-    private static final MongoClientOptions DEFAULT_MONGO_OPTIONS = MongoClientOptions.builder().build();
+    private static final Log _sLog = LogFactory.getLog(MongoClientOptionsFactoryBean.class);
 
-//    private String description = DEFAULT_MONGO_OPTIONS.getDescription();
+    private static final MongoClientOptions DEFAULT_MONGO_OPTIONS = MongoClientOptions
+            .builder()
+            .build();
+
+    private String applicationName = DEFAULT_MONGO_OPTIONS.getApplicationName();
+    private List<com.mongodb.MongoCompressor> compressorList = DEFAULT_MONGO_OPTIONS.getCompressorList();
+    private ReadPreference readPreference = DEFAULT_MONGO_OPTIONS.getReadPreference();
+    private WriteConcern writeConcern = DEFAULT_MONGO_OPTIONS.getWriteConcern();
+    private boolean retryWrites = DEFAULT_MONGO_OPTIONS.getRetryWrites();
+    private boolean retryReads = DEFAULT_MONGO_OPTIONS.getRetryReads();
+    private ReadConcern readConcern = DEFAULT_MONGO_OPTIONS.getReadConcern();
+    private CodecRegistry codecRegistry = DEFAULT_MONGO_OPTIONS.getCodecRegistry();
+    private UuidRepresentation uuidRepresentation = DEFAULT_MONGO_OPTIONS.getUuidRepresentation();
+    private ServerSelector serverSelector = DEFAULT_MONGO_OPTIONS.getServerSelector();
     private int minConnectionsPerHost = DEFAULT_MONGO_OPTIONS.getMinConnectionsPerHost();
-    private int connectionsPerHost = DEFAULT_MONGO_OPTIONS.getConnectionsPerHost();
-//    private int threadsAllowedToBlockForConnectionMultiplier = DEFAULT_MONGO_OPTIONS
-//            .getThreadsAllowedToBlockForConnectionMultiplier();
+    private int maxConnectionsPerHost = DEFAULT_MONGO_OPTIONS.getConnectionsPerHost();
+    private int serverSelectionTimeout = DEFAULT_MONGO_OPTIONS.getServerSelectionTimeout();
     private int maxWaitTime = DEFAULT_MONGO_OPTIONS.getMaxWaitTime();
     private int maxConnectionIdleTime = DEFAULT_MONGO_OPTIONS.getMaxConnectionIdleTime();
     private int maxConnectionLifeTime = DEFAULT_MONGO_OPTIONS.getMaxConnectionLifeTime();
     private int connectTimeout = DEFAULT_MONGO_OPTIONS.getConnectTimeout();
     private int socketTimeout = DEFAULT_MONGO_OPTIONS.getSocketTimeout();
-//    private boolean socketKeepAlive = DEFAULT_MONGO_OPTIONS.isSocketKeepAlive();
-    private ReadPreference readPreference = DEFAULT_MONGO_OPTIONS.getReadPreference();
-    private DBDecoderFactory dbDecoderFactory = DEFAULT_MONGO_OPTIONS.getDbDecoderFactory();
-    private DBEncoderFactory dbEncoderFactory = DEFAULT_MONGO_OPTIONS.getDbEncoderFactory();
-    private WriteConcern writeConcern = DEFAULT_MONGO_OPTIONS.getWriteConcern();
-//    private SocketFactory socketFactory = DEFAULT_MONGO_OPTIONS.getSocketFactory();
-    private boolean cursorFinalizerEnabled = DEFAULT_MONGO_OPTIONS.isCursorFinalizerEnabled();
-//    private boolean alwaysUseMBeans = DEFAULT_MONGO_OPTIONS.isAlwaysUseMBeans();
+    private boolean sslEnabled = DEFAULT_MONGO_OPTIONS.isSslEnabled();
+    private boolean sslInvalidHostNameAllowed = DEFAULT_MONGO_OPTIONS.isSslInvalidHostNameAllowed();
+    private SSLContext sslContext = DEFAULT_MONGO_OPTIONS.getSslContext();
     private int heartbeatFrequency = DEFAULT_MONGO_OPTIONS.getHeartbeatFrequency();
     private int minHeartbeatFrequency = DEFAULT_MONGO_OPTIONS.getMinHeartbeatFrequency();
     private int heartbeatConnectTimeout = DEFAULT_MONGO_OPTIONS.getHeartbeatConnectTimeout();
     private int heartbeatSocketTimeout = DEFAULT_MONGO_OPTIONS.getHeartbeatSocketTimeout();
+    private int localThreshold = DEFAULT_MONGO_OPTIONS.getLocalThreshold();
     private String requiredReplicaSetName = DEFAULT_MONGO_OPTIONS.getRequiredReplicaSetName();
+    private DBDecoderFactory dbDecoderFactory = DEFAULT_MONGO_OPTIONS.getDbDecoderFactory();
+    private DBEncoderFactory dbEncoderFactory = DEFAULT_MONGO_OPTIONS.getDbEncoderFactory();
+    private boolean cursorFinalizerEnabled = DEFAULT_MONGO_OPTIONS.isCursorFinalizerEnabled();
+    private List<com.mongodb.event.ClusterListener> clusterListeners = DEFAULT_MONGO_OPTIONS.getClusterListeners();
+    private List<com.mongodb.event.CommandListener> commandListeners = DEFAULT_MONGO_OPTIONS.getCommandListeners();
+    private AutoEncryptionSettings autoEncryptionSettings = DEFAULT_MONGO_OPTIONS.getAutoEncryptionSettings();
 
-    private boolean ssl;
-    private SSLSocketFactory sslSocketFactory;
 
+    @Deprecated
+    public void setThreadsAllowedToBlockForConnectionMultiplier(int threadsAllowedToBlockForConnectionMultiplier) {
+        _sLog.warn("Use of setThreadsAllowedToBlockForConnectionMultiplier is deprecated, this setting will have no affect!");
+    }
 
-    /**
-     * Set the minimum number of connections per host.
-     *
-     * @param minConnectionsPerHost
-     */
-    public void setMinConnectionsPerHost(int minConnectionsPerHost) {
-        this.minConnectionsPerHost = minConnectionsPerHost;
+    @Deprecated
+    public void setSocketKeepAlive(boolean socketKeepAlive) {
+        _sLog.warn("Use of setSocketKeepAlive is deprecated, this setting will have no affect!");
+    }
+
+    @Deprecated
+    public void setSocketFactory(SocketFactory socketFactory) {
+        _sLog.warn("Use of setSocketFactory is deprecated, this setting will have no affect!");
+    }
+
+    @Deprecated
+    public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+        _sLog.warn("Use of setSslSocketFactory is deprecated, this setting will have no affect!");
     }
 
     /**
-     * Set the number of connections allowed per host. Will block if run out. Default is 10. System property
-     * {@code MONGO.POOLSIZE} can override
-     *
-     * @param connectionsPerHost
+     * @see com.mongodb.MongoClientOptions
+     * @param applicationName
      */
-    public void setConnectionsPerHost(int connectionsPerHost) {
-        this.connectionsPerHost = connectionsPerHost;
-    }
-
-//    /**
-//     * Set the multiplier for connectionsPerHost for # of threads that can block. Default is 5. If connectionsPerHost is
-//     * 10, and threadsAllowedToBlockForConnectionMultiplier is 5, then 50 threads can block more than that and an
-//     * exception will be thrown.
-//     *
-//     * @param threadsAllowedToBlockForConnectionMultiplier
-//     */
-//    public void setThreadsAllowedToBlockForConnectionMultiplier(int threadsAllowedToBlockForConnectionMultiplier) {
-//        this.threadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;
-//    }
-
-    /**
-     * Set the max wait time of a blocking thread for a connection. Default is 12000 ms (2 minutes)
-     *
-     * @param maxWaitTime
-     */
-    public void setMaxWaitTime(int maxWaitTime) {
-        this.maxWaitTime = maxWaitTime;
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
     }
 
     /**
-     * The maximum idle time for a pooled connection.
-     *
-     * @param maxConnectionIdleTime
+     * @see com.mongodb.MongoClientOptions
+     * @param compressorList
      */
-    public void setMaxConnectionIdleTime(int maxConnectionIdleTime) {
-        this.maxConnectionIdleTime = maxConnectionIdleTime;
+    public void setCompressorList(List<MongoCompressor> compressorList) {
+        this.compressorList = compressorList;
     }
 
     /**
-     * Set the maximum life time for a pooled connection.
-     *
-     * @param maxConnectionLifeTime
-     */
-    public void setMaxConnectionLifeTime(int maxConnectionLifeTime) {
-        this.maxConnectionLifeTime = maxConnectionLifeTime;
-    }
-
-    /**
-     * Set the connect timeout in milliseconds. 0 is default and infinite.
-     *
-     * @param connectTimeout
-     */
-    public void setConnectTimeout(int connectTimeout) {
-        this.connectTimeout = connectTimeout;
-    }
-
-    /**
-     * Set the socket timeout. 0 is default and infinite.
-     *
-     * @param socketTimeout
-     */
-    public void setSocketTimeout(int socketTimeout) {
-        this.socketTimeout = socketTimeout;
-    }
-
-//    /**
-//     * Set the keep alive flag, controls whether or not to have socket keep alive timeout. Defaults to false.
-//     *
-//     * @param socketKeepAlive
-//     */
-//    public void setSocketKeepAlive(boolean socketKeepAlive) {
-//        this.socketKeepAlive = socketKeepAlive;
-//    }
-
-    /**
-     * Set the {@link ReadPreference}.
-     *
+     * @see com.mongodb.MongoClientOptions
      * @param readPreference
      */
     public void setReadPreference(ReadPreference readPreference) {
@@ -140,30 +114,151 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
     }
 
     /**
-     * Set the {@link WriteConcern} that will be the default value used when asking the MongoDbFactory for a DB
-     * object.
-     *
+     * @see com.mongodb.MongoClientOptions
      * @param writeConcern
      */
     public void setWriteConcern(WriteConcern writeConcern) {
         this.writeConcern = writeConcern;
     }
 
-//    /**
-//     * @param socketFactory
-//     */
-//    public void setSocketFactory(SocketFactory socketFactory) {
-//        this.socketFactory = socketFactory;
-//    }
-
-
-    public void setCursorFinalizerEnabled(boolean cursorFinalizerEnabled) {
-        this.cursorFinalizerEnabled = cursorFinalizerEnabled;
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param retryWrites
+     */
+    public void setRetryWrites(boolean retryWrites) {
+        this.retryWrites = retryWrites;
     }
 
     /**
-     * Set the frequency that the driver will attempt to determine the current state of each server in the cluster.
-     *
+     * @see com.mongodb.MongoClientOptions
+     * @param retryReads
+     */
+    public void setRetryReads(boolean retryReads) {
+        this.retryReads = retryReads;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param readConcern
+     */
+    public void setReadConcern(ReadConcern readConcern) {
+        this.readConcern = readConcern;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param codecRegistry
+     */
+    public void setCodecRegistry(CodecRegistry codecRegistry) {
+        this.codecRegistry = codecRegistry;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param uuidRepresentation
+     */
+    public void setUuidRepresentation(UuidRepresentation uuidRepresentation) {
+        this.uuidRepresentation = uuidRepresentation;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param serverSelector
+     */
+    public void setServerSelector(ServerSelector serverSelector) {
+        this.serverSelector = serverSelector;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param minConnectionsPerHost
+     */
+    public void setMinConnectionsPerHost(int minConnectionsPerHost) {
+        this.minConnectionsPerHost = minConnectionsPerHost;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param maxConnectionsPerHost
+     */
+    public void setMaxConnectionsPerHost(int maxConnectionsPerHost) {
+        this.maxConnectionsPerHost = maxConnectionsPerHost;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param serverSelectionTimeout
+     */
+    public void setServerSelectionTimeout(int serverSelectionTimeout) {
+        this.serverSelectionTimeout = serverSelectionTimeout;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param maxWaitTime
+     */
+    public void setMaxWaitTime(int maxWaitTime) {
+        this.maxWaitTime = maxWaitTime;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param maxConnectionIdleTime
+     */
+    public void setMaxConnectionIdleTime(int maxConnectionIdleTime) {
+        this.maxConnectionIdleTime = maxConnectionIdleTime;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param maxConnectionLifeTime
+     */
+    public void setMaxConnectionLifeTime(int maxConnectionLifeTime) {
+        this.maxConnectionLifeTime = maxConnectionLifeTime;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param connectTimeout
+     */
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param socketTimeout
+     */
+    public void setSocketTimeout(int socketTimeout) {
+        this.socketTimeout = socketTimeout;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param sslEnabled
+     */
+    public void setSslEnabled(boolean sslEnabled) {
+        this.sslEnabled = sslEnabled;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param sslInvalidHostNameAllowed
+     */
+    public void setSslInvalidHostNameAllowed(boolean sslInvalidHostNameAllowed) {
+        this.sslInvalidHostNameAllowed = sslInvalidHostNameAllowed;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param sslContext
+     */
+    public void setSslContext(SSLContext sslContext) {
+        this.sslContext = sslContext;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
      * @param heartbeatFrequency
      */
     public void setHeartbeatFrequency(int heartbeatFrequency) {
@@ -171,9 +266,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
     }
 
     /**
-     * In the event that the driver has to frequently re-check a server's availability, it will wait at least this long
-     * since the previous check to avoid wasted effort.
-     *
+     * @see com.mongodb.MongoClientOptions
      * @param minHeartbeatFrequency
      */
     public void setMinHeartbeatFrequency(int minHeartbeatFrequency) {
@@ -181,8 +274,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
     }
 
     /**
-     * Set the connect timeout for connections used for the cluster heartbeat.
-     *
+     * @see com.mongodb.MongoClientOptions
      * @param heartbeatConnectTimeout
      */
     public void setHeartbeatConnectTimeout(int heartbeatConnectTimeout) {
@@ -190,8 +282,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
     }
 
     /**
-     * Set the socket timeout for connections used for the cluster heartbeat.
-     *
+     * @see com.mongodb.MongoClientOptions
      * @param heartbeatSocketTimeout
      */
     public void setHeartbeatSocketTimeout(int heartbeatSocketTimeout) {
@@ -199,8 +290,15 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
     }
 
     /**
-     * Configures the name of the replica set.
-     *
+     * @see com.mongodb.MongoClientOptions
+     * @param localThreshold
+     */
+    public void setLocalThreshold(int localThreshold) {
+        this.localThreshold = localThreshold;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
      * @param requiredReplicaSetName
      */
     public void setRequiredReplicaSetName(String requiredReplicaSetName) {
@@ -208,63 +306,98 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
     }
 
     /**
-     * This controls if the driver should us an SSL connection. Defaults to |@literal false}.
-     *
-     * @param ssl
+     * @see com.mongodb.MongoClientOptions
+     * @param dbDecoderFactory
      */
-    public void setSsl(boolean ssl) {
-        this.ssl = ssl;
+    public void setDbDecoderFactory(DBDecoderFactory dbDecoderFactory) {
+        this.dbDecoderFactory = dbDecoderFactory;
     }
 
     /**
-     * Set the {@link SSLSocketFactory} to use for the {@literal SSL} connection. If none is configured here,
-     * {@link SSLSocketFactory#getDefault()} will be used.
-     *
-     * @param sslSocketFactory
+     * @see com.mongodb.MongoClientOptions
+     * @param dbEncoderFactory
      */
-    public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
-        this.sslSocketFactory = sslSocketFactory;
+    public void setDbEncoderFactory(DBEncoderFactory dbEncoderFactory) {
+        this.dbEncoderFactory = dbEncoderFactory;
     }
 
-    /*
-     * (non-Javadoc)
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param cursorFinalizerEnabled
+     */
+    public void setCursorFinalizerEnabled(boolean cursorFinalizerEnabled) {
+        this.cursorFinalizerEnabled = cursorFinalizerEnabled;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param clusterListeners
+     */
+    public void setClusterListeners(List<ClusterListener> clusterListeners) {
+        this.clusterListeners = clusterListeners;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param commandListeners
+     */
+    public void setCommandListeners(List<CommandListener> commandListeners) {
+        this.commandListeners = commandListeners;
+    }
+
+    /**
+     * @see com.mongodb.MongoClientOptions
+     * @param autoEncryptionSettings
+     */
+    public void setAutoEncryptionSettings(AutoEncryptionSettings autoEncryptionSettings) {
+        this.autoEncryptionSettings = autoEncryptionSettings;
+    }
+
+    /**
      * @see org.springframework.beans.factory.config.AbstractFactoryBean#createInstance()
      */
     @Override
-    protected MongoClientOptions createInstance() throws Exception {
+    protected MongoClientOptions createInstance() {
 
-    //        SocketFactory socketFactoryToUse = ssl ? (sslSocketFactory != null ? sslSocketFactory : SSLSocketFactory
-    //                .getDefault()) : this.socketFactory;
-
-        return MongoClientOptions.builder() //
-//                .alwaysUseMBeans(this.alwaysUseMBeans) //
-                .connectionsPerHost(this.connectionsPerHost) //
-                .connectTimeout(connectTimeout) //
-                .cursorFinalizerEnabled(cursorFinalizerEnabled) //
-                .dbDecoderFactory(dbDecoderFactory) //
-                .dbEncoderFactory(dbEncoderFactory) //
-//                .description(description) //
-                .heartbeatConnectTimeout(heartbeatConnectTimeout) //
-                .heartbeatFrequency(heartbeatFrequency) //
-                .heartbeatSocketTimeout(heartbeatSocketTimeout) //
-                .maxConnectionIdleTime(maxConnectionIdleTime) //
-                .maxConnectionLifeTime(maxConnectionLifeTime) //
-                .maxWaitTime(maxWaitTime) //
-                .minConnectionsPerHost(minConnectionsPerHost) //
-                .minHeartbeatFrequency(minHeartbeatFrequency) //
-                .readPreference(readPreference) //
-                .requiredReplicaSetName(requiredReplicaSetName) //
-//                .socketFactory(socketFactoryToUse) //
-//                .socketKeepAlive(socketKeepAlive) //
-                .socketTimeout(socketTimeout) //
-//                .threadsAllowedToBlockForConnectionMultiplier(threadsAllowedToBlockForConnectionMultiplier) //
-                .writeConcern(writeConcern).build();
+        return MongoClientOptions.builder()
+                .applicationName(this.applicationName)
+                .compressorList(this.compressorList)
+                .readPreference(this.readPreference)
+                .writeConcern(this.writeConcern)
+                .retryWrites(this.retryWrites)
+                .retryReads(this.retryReads)
+                .readConcern(this.readConcern)
+                .codecRegistry(this.codecRegistry)
+                .uuidRepresentation(this.uuidRepresentation)
+                .serverSelector(this.serverSelector)
+                .minConnectionsPerHost(this.minConnectionsPerHost)
+                .connectionsPerHost(this.maxConnectionsPerHost)
+                .serverSelectionTimeout(this.serverSelectionTimeout)
+                .maxWaitTime(this.maxWaitTime)
+                .maxConnectionIdleTime(this.maxConnectionIdleTime)
+                .maxConnectionLifeTime(this.maxConnectionLifeTime)
+                .connectTimeout(this.connectTimeout)
+                .socketTimeout(this.socketTimeout)
+                .sslEnabled(this.sslEnabled)
+                .sslInvalidHostNameAllowed(this.sslInvalidHostNameAllowed)
+                .sslContext(this.sslContext)
+                .heartbeatFrequency(this.heartbeatFrequency)
+                .minHeartbeatFrequency(this.minHeartbeatFrequency)
+                .heartbeatConnectTimeout(this.heartbeatConnectTimeout)
+                .heartbeatSocketTimeout(this.heartbeatSocketTimeout)
+                .localThreshold(this.localThreshold)
+                .requiredReplicaSetName(this.requiredReplicaSetName)
+                .dbDecoderFactory(this.dbDecoderFactory)
+                .dbEncoderFactory(this.dbEncoderFactory)
+                .cursorFinalizerEnabled(this.cursorFinalizerEnabled)
+                .autoEncryptionSettings(this.autoEncryptionSettings)
+                .build();
     }
 
-    /*
-     * (non-Javadoc)
+    /**
      * @see org.springframework.beans.factory.FactoryBean#getObjectType()
      */
+    @Override
     public Class<?> getObjectType() {
         return MongoClientOptions.class;
     }

--- a/mongodao/src/main/java/com/bazaarvoice/commons/data/dao/mongo/MongoClientOptionsFactoryBean.java
+++ b/mongodao/src/main/java/com/bazaarvoice/commons/data/dao/mongo/MongoClientOptionsFactoryBean.java
@@ -45,7 +45,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
     private UuidRepresentation uuidRepresentation = DEFAULT_MONGO_OPTIONS.getUuidRepresentation();
     private ServerSelector serverSelector = DEFAULT_MONGO_OPTIONS.getServerSelector();
     private int minConnectionsPerHost = DEFAULT_MONGO_OPTIONS.getMinConnectionsPerHost();
-    private int maxConnectionsPerHost = DEFAULT_MONGO_OPTIONS.getConnectionsPerHost();
+    private int connectionsPerHost = DEFAULT_MONGO_OPTIONS.getConnectionsPerHost();
     private int serverSelectionTimeout = DEFAULT_MONGO_OPTIONS.getServerSelectionTimeout();
     private int maxWaitTime = DEFAULT_MONGO_OPTIONS.getMaxWaitTime();
     private int maxConnectionIdleTime = DEFAULT_MONGO_OPTIONS.getMaxConnectionIdleTime();
@@ -68,6 +68,11 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
     private List<com.mongodb.event.CommandListener> commandListeners = DEFAULT_MONGO_OPTIONS.getCommandListeners();
     private AutoEncryptionSettings autoEncryptionSettings = DEFAULT_MONGO_OPTIONS.getAutoEncryptionSettings();
 
+
+    @Deprecated
+    public void setDescription(String description) {
+        _sLog.warn("Use of setDescription is deprecated, this setting will have no affect!");
+    }
 
     @Deprecated
     public void setThreadsAllowedToBlockForConnectionMultiplier(int threadsAllowedToBlockForConnectionMultiplier) {
@@ -179,10 +184,10 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
 
     /**
      * @see com.mongodb.MongoClientOptions
-     * @param maxConnectionsPerHost
+     * @param connectionsPerHost
      */
-    public void setMaxConnectionsPerHost(int maxConnectionsPerHost) {
-        this.maxConnectionsPerHost = maxConnectionsPerHost;
+    public void setConnectionsPerHost(int connectionsPerHost) {
+        this.connectionsPerHost = connectionsPerHost;
     }
 
     /**
@@ -371,7 +376,7 @@ public class MongoClientOptionsFactoryBean extends AbstractFactoryBean<MongoClie
                 .uuidRepresentation(this.uuidRepresentation)
                 .serverSelector(this.serverSelector)
                 .minConnectionsPerHost(this.minConnectionsPerHost)
-                .connectionsPerHost(this.maxConnectionsPerHost)
+                .connectionsPerHost(this.connectionsPerHost)
                 .serverSelectionTimeout(this.serverSelectionTimeout)
                 .maxWaitTime(this.maxWaitTime)
                 .maxConnectionIdleTime(this.maxConnectionIdleTime)

--- a/mongodao/src/main/java/com/bazaarvoice/commons/data/dao/mongo/MongoCredentialsFactoryBean.java
+++ b/mongodao/src/main/java/com/bazaarvoice/commons/data/dao/mongo/MongoCredentialsFactoryBean.java
@@ -1,0 +1,30 @@
+package com.bazaarvoice.commons.data.dao.mongo;
+
+import com.mongodb.MongoCredential;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+
+/**
+ * Spring factory bean for construction of a {@link MongoCredential} instance
+ */
+public class MongoCredentialsFactoryBean extends AbstractFactoryBean<MongoCredential> {
+
+    private final String username;
+    private final String password;
+    private final String authDatabaseName;
+
+    public MongoCredentialsFactoryBean(String username, String password, String authDatabaseName) {
+        this.username = username;
+        this.password = password;
+        this.authDatabaseName = authDatabaseName;
+    }
+
+    @Override
+    protected MongoCredential createInstance() {
+        return MongoCredential.createCredential(username, authDatabaseName, password.toCharArray());
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return MongoCredential.class;
+    }
+}

--- a/mongodao/src/main/java/com/bazaarvoice/commons/data/dao/mongo/impl/MongoAccessServiceImpl.java
+++ b/mongodao/src/main/java/com/bazaarvoice/commons/data/dao/mongo/impl/MongoAccessServiceImpl.java
@@ -9,6 +9,7 @@ import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.gridfs.GridFS;
 import org.apache.commons.lang3.StringUtils;
@@ -31,6 +32,7 @@ public class MongoAccessServiceImpl implements MongoAccessService {
     private boolean _useGridFS = false;
     private String _gridFSDatabaseName;
     private MongoClientOptions _mongoClientOptions = MongoClientOptions.builder().build();
+    private MongoCredential _mongoCredentials;
 
     private String _sequenceCollectionName = DEFAULT_SEQUENCE_COLLECTION_NAME;
 
@@ -60,13 +62,21 @@ public class MongoAccessServiceImpl implements MongoAccessService {
     }
 
     /**
-     * MongoClientOptions to pass into the mongo constructor
+     * MongoClientOptions to pass into the mongo client constructor
      * @see com.mongodb.MongoClientOptions
-     *
-     * @param mongoClientOptions the mongo options to use
+     * @param mongoClientOptions
      */
     public void setMongoClientOptions(MongoClientOptions mongoClientOptions) {
         _mongoClientOptions = mongoClientOptions;
+    }
+
+    /**
+     * Optional credentials to configure on the mongo client
+     * @see com.mongodb.MongoCredential
+     * @param credentials
+     */
+    public void setMongoCredential(MongoCredential credentials) {
+        _mongoCredentials = credentials;
     }
 
     @PostConstruct
@@ -87,7 +97,12 @@ public class MongoAccessServiceImpl implements MongoAccessService {
             _sLog.info("Initializing mongoDB '" + _databaseName + "' with servers: " + serverAddressList);
         }
 
-        _mongoClient = new MongoClient(serverAddressList, _mongoClientOptions);
+
+        if(_mongoCredentials == null) {
+            _mongoClient = new MongoClient(serverAddressList, _mongoClientOptions);
+        } else {
+            _mongoClient = new MongoClient(serverAddressList, _mongoCredentials, _mongoClientOptions);
+        }
 
         if (_useGridFS) {
             if (StringUtils.isNotBlank(_gridFSDatabaseName)) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.bazaarvoice.commons.data</groupId>
     <artifactId>data-parent</artifactId>
-    <version>4.5-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Bazaarvoice Commons Data DAO Parent</name>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.bazaarvoice.commons</groupId>
         <artifactId>bv-opensource-super-pom</artifactId>
         <version>1.4</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <groupId>com.bazaarvoice.commons.data</groupId>
@@ -18,9 +18,16 @@
     <name>Bazaarvoice Commons Data DAO Parent</name>
 
     <properties>
-        <springframework.version>4.3.13.RELEASE</springframework.version>
-        <metrics.version>3.2.5</metrics.version>
+        <springframework.version>5.3.3</springframework.version>
+        <metrics.version>4.1.2</metrics.version>
         <gwt.version>2.8.2</gwt.version>
+        <mongodb-driver-legacy.version>4.2.0</mongodb-driver-legacy.version>
+        <json.version>20201115</json.version>
+        <guava.version>30.1-jre</guava.version>
+        <commons-logging.version>1.2</commons-logging.version>
+        <commons-io.version>2.8.0</commons-io.version>
+        <commons-lang3.version>3.11</commons-lang3.version>
+        <jsr305.version>3.0.2</jsr305.version>
         <additionalparam>-Xdoclint:none</additionalparam>
     </properties>
 
@@ -47,13 +54,13 @@
             <!-- Data -->
             <dependency>
                 <groupId>org.mongodb</groupId>
-                <artifactId>mongo-java-driver</artifactId>
-                <version>3.7.1</version>
+                <artifactId>mongodb-driver-legacy</artifactId>
+                <version>${mongodb-driver-legacy.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
-                <version>20160810</version>
+                <version>${json.version}</version>
             </dependency>
 
             <!-- Metrics -->
@@ -72,34 +79,34 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>20.0</version>
+                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
-                <version>3.0.2</version>
+                <version>${jsr305.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
-                <version>1.2</version>
+                <version>${commons-logging.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.7</version>
+                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.6</version>
+                <version>${commons-io.version}</version>
             </dependency>
 
             <!-- Testing -->
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>6.13.1</version>
+                <version>6.14.3</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -129,13 +136,26 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <version>3.0.0-M5</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.0.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>6.1.0</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.commons.data</groupId>
         <artifactId>data-parent</artifactId>
-        <version>4.5-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
         <relativePath>parent/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
- Update all dependencies (including the mongodb driver) to the latest versions
- Deprecate old Mongo implementation options but don't prevent them from being used
- Add ability to use MongoCredential to support optional authentication
- Bump major version from 4 to 5
- Add usage example to readme